### PR TITLE
Endpoint output

### DIFF
--- a/src/starpack/__main__.py
+++ b/src/starpack/__main__.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from rich import print
+from rich.pretty import pprint
 
 import typer
 
@@ -12,6 +13,7 @@ from starpack import (
     package_directory,
     deploy_directory,
 )
+from starpack._config import settings
 
 app = typer.Typer(pretty_exceptions_show_locals=False)
 
@@ -22,6 +24,25 @@ app.add_typer(
     name="engine",
     help="Commands to control and manipulate the Starpack Engine itself.",
 )
+
+# Config app for changing config
+
+config_app = typer.Typer(pretty_exceptions_show_locals=False)
+
+app.add_typer(
+    config_app,
+    name="config",
+    help="View the current Starpack Configuration. You can edit this configuration manually at ~/.starpack/",
+    hidden=True
+)
+
+
+@config_app.command(name="view")
+def cmd_view_config():
+    """
+    View a pretty-printed version of the config, found
+    """
+    pprint(settings, expand_all=True)
 
 
 @engine_app.command(name="start")

--- a/src/starpack/_config.py
+++ b/src/starpack/_config.py
@@ -17,6 +17,7 @@ ENV_FILE.touch()
 class Settings(BaseSettings):
     engine_port: int = 1976
     engine_image: str = "starpack/starpack-engine:latest"
+    pull_image: bool = True
     app_name: str = APP_NAME
     app_dir: Path = APP_DIR
     plugins_dir: Optional[Path] = None

--- a/src/starpack/client.py
+++ b/src/starpack/client.py
@@ -72,7 +72,10 @@ class StarpackClient:
         output = requests.post(deploy_url, json=payload)
 
         if output.status_code / 100 == 2:
-            print(f"Successfully deployed {payload['deployment']['metadata']['name']}")
+            endpoint = output.json().get("endpoint")
+            if not endpoint:
+                endpoint = "unknown location. Please check Docker to find your running container."
+            print(f"Successfully deployed {payload['deployment']['metadata']['name']} at {endpoint}")
         else:
             print(output.status_code)
             print(output.text)
@@ -128,7 +131,8 @@ class StarpackClient:
         self.docker_client.volumes.create(
             name=self.volumes["artifacts"]["host"], labels={"app": self.app_label}
         )
-        self.docker_client.images.pull(settings.engine_image)
+        if settings.pull_image:
+            self.docker_client.images.pull(settings.engine_image)
 
         print(f"Starting Starpack Engine at {self.url}")
         self.engine = self.docker_client.containers.run(

--- a/src/tests/test_engine_client.py
+++ b/src/tests/test_engine_client.py
@@ -39,14 +39,14 @@ def test_client_healthcheck(
 
 @pytest.mark.parametrize(
     ("status_code", "output"),
-    [(200, "Successfully deployed"), (500, "500"), (300, "300")],
+    [(200, "http://localhost:2000"), (500, "500"), (300, "300")],
 )
 def test_client_deploy(
     starpack_client, requests_mock, capsys, status_code: int, output: str
 ):
     url = "http://localhost:1976/deploy"
     payload = {"deployment": {"metadata": {"name": "test"}}}
-    requests_mock.post(url, status_code=status_code, text="")
+    requests_mock.post(url, status_code=status_code, json={"endpoint": "http://localhost:2000"})
     starpack_client.deploy(payload)
     print_out = capsys.readouterr().out
 


### PR DESCRIPTION
## Summary

Added the output for the deploy command so people can access their final models easily.

Added a simple config viewer in the commands

## Testing

`pytest` to confirm working tests

Run a deployment to see the deployed endpoint name

Run  `starpack config view` to see the current config
